### PR TITLE
update brightness.url when color is set

### DIFF
--- a/index.js
+++ b/index.js
@@ -328,8 +328,8 @@ HTTP_RGB.prototype = {
         }
         this.cache.brightness = level;
 
-        // If achromatic, then update brightness, otherwise, update HSL as RGB
-        if (!this.color) {
+        // If achromatic or color.brightness is false, update brightness, otherwise, update HSL as RGB
+        if (!this.color || !this.color.brightness) {
             var url = this.brightness.set_url.replace('%s', level);
 
             this._httpRequest(url, '', this.brightness.http_method, function(error, response, body) {


### PR DESCRIPTION
make use of color.brightness setting to switch between brightness.url or hsl method.
• set color.brightness to false or unset to update brightness.url
• set color.brightness to true to update HSL as RGB

_setRGB seems to change the saturation instead of the brightness though, but i have not investigated that further.
(see issue #14)